### PR TITLE
Removed missing package

### DIFF
--- a/lib/ckafka.rb
+++ b/lib/ckafka.rb
@@ -1,5 +1,4 @@
 require "ckafka/version"
-require 'ckafka/ckafka.bundle'
 
 module Ckafka
 end


### PR DESCRIPTION
`ckafka/ckafka.bundle` doesn't exist and causes errors when trying to load it.

cc @ibawt 

https://circleci.com/gh/Shopify/kafka-shopify/992
