### PR TITLE
Adding ext dir to the gemspec

### DIFF
--- a/ckafka.gemspec
+++ b/ckafka.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ["lib", 'ext']
+  spec.platform = Gem::Platform::CURRENT
   spec.extensions = %w(ext/ckafka/extconf.rb)
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I realized after in #1 that the problem was that the correct directories for compiling and building the gem weren't included to generate `ckafka/ckafka.bundle`
