### PR TITLE
Rename require statement to support other systems

### DIFF
--- a/lib/ckafka.rb
+++ b/lib/ckafka.rb
@@ -1,5 +1,5 @@
 require "ckafka/version"
-require 'ckafka/ckafka.bundle'
+require 'ckafka/ckafka'
 
 module Ckafka
 end

--- a/lib/ckafka/version.rb
+++ b/lib/ckafka/version.rb
@@ -1,3 +1,3 @@
 module Ckafka
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
On other systems such as ubuntu running in CI builds the previous version would fail on load because the extension gets created as `ckafka/ckafka.so`. This PR renames the requiring statement to make it agnostic of the environment and the compiled file extension.
