### PR TITLE
looks like we need not call topic_destroy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,9 @@ dependencies:
     - make confluent/rest/start
     - confluent/bin/kafka-topics --create --topic test.1  --partitions 1  --replication-factor 1 --zookeeper localhost
     - >
-      git clone git@github.com:edenhill/librdkafka.git ~/librdkafka;
-      cd ~/librdkafka;
-      git reset --hard d5799beb5cc23459e7dd1ab25ea43d97c7a80aff;
-      ./configure;
-      make;
-      sudo make install
+      add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu trusty main universe";
+      apt-get update;
+      apt-get install librdkafka-dev;
   post:
     - confluent/bin/kafka-topics --list --zookeeper localhost
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ dependencies:
     - make confluent/rest/start
     - confluent/bin/kafka-topics --create --topic test.1  --partitions 1  --replication-factor 1 --zookeeper localhost
     - >
-      add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu trusty main universe";
-      apt-get update;
-      apt-get install librdkafka-dev;
+      sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu trusty main universe";
+      sudo apt-get update;
+      sudo apt-get install librdkafka-dev=0.8.3-1ubuntu2;
   post:
     - confluent/bin/kafka-topics --list --zookeeper localhost
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,12 @@ dependencies:
     - make confluent/rest/start
     - confluent/bin/kafka-topics --create --topic test.1  --partitions 1  --replication-factor 1 --zookeeper localhost
     - >
-      sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu trusty main universe";
-      sudo apt-get update;
-      sudo apt-get install librdkafka-dev=0.8.3-1ubuntu2;
+      git clone git@github.com:edenhill/librdkafka.git ~/librdkafka;
+      cd ~/librdkafka;
+      git reset --hard 0c15023708302c41a36e95f9650d69c453dfabba;
+      ./configure;
+      make;
+      sudo make install
   post:
     - confluent/bin/kafka-topics --list --zookeeper localhost
 

--- a/ext/ckafka/ckafka.c
+++ b/ext/ckafka/ckafka.c
@@ -9,54 +9,6 @@
 
 static rd_kafka_t *rk = NULL;
 
-typedef struct _topic_cache_node {
-  char *name;
-  rd_kafka_topic_t *topic;
-  struct _topic_cache_node *next;
-} topic_cache_node;
-
-static topic_cache_node *topic_cache = NULL;
-
-static rd_kafka_topic_t* topic_for_name(const char *name)
-{
-  topic_cache_node *cur = topic_cache;
-
-  while(cur) {
-    if( strncmp(cur->name, name, 256) == 0 ) {
-      return cur->topic;
-    }
-
-    cur = cur->next;
-  }
-
-  topic_cache_node *t = malloc(sizeof(topic_cache_node));
-  t->name = strdup(name);
-  t->next = topic_cache;
-
-  rd_kafka_topic_conf_t *tc = rd_kafka_topic_conf_new();
-  t->topic = rd_kafka_topic_new(rk, name, tc);
-
-  topic_cache = t;
-
-  return t->topic;
-}
-
-static void clear_topic_cache(void)
-{
-  topic_cache_node *cur = topic_cache;
-
-  while( cur ) {
-    topic_cache_node *t = cur;
-    cur = t->next;
-
-    rd_kafka_topic_destroy(t->topic);
-    free(t->name);
-    free(t);
-  }
-
-  topic_cache = NULL;
-}
-
 static void error(const char *fmt, ...)
 {
   va_list args;
@@ -104,8 +56,15 @@ static VALUE kafka_send(VALUE self, VALUE topic_value, VALUE key, VALUE message)
   }
 
 
-  topic = topic_for_name(topic_name);
-  assert(topic);
+  topic_conf = rd_kafka_topic_conf_new();
+  if(!topic_conf) {
+    rb_raise(rb_eStandardError, "failed to create kafka topic configuration");
+  }
+
+  topic = rd_kafka_topic_new(rk, topic_name, topic_conf);
+  if(!topic) {
+    rb_raise(rb_eStandardError, "failed to create topic");
+  }
 
   res = rd_kafka_produce(topic, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_COPY, message_bytes, message_len,
                          key_buf, key_len, NULL);
@@ -120,7 +79,6 @@ static VALUE kafka_send(VALUE self, VALUE topic_value, VALUE key, VALUE message)
 static VALUE kafka_destroy()
 {
   if(rk) {
-    clear_topic_cache();
     for(int i = 0 ; i < MAX_SHUTDOWN_TRIES; ++i) {
       if(!rd_kafka_outq_len(rk)) {
         break;

--- a/ext/ckafka/ckafka.c
+++ b/ext/ckafka/ckafka.c
@@ -79,7 +79,8 @@ static VALUE kafka_send(VALUE self, VALUE topic_value, VALUE key, VALUE message)
 static VALUE kafka_destroy()
 {
   if(rk) {
-    for(int i = 0 ; i < MAX_SHUTDOWN_TRIES; ++i) {
+    int i,res;
+    for(i = 0 ; i < MAX_SHUTDOWN_TRIES; ++i) {
       if(!rd_kafka_outq_len(rk)) {
         break;
       }
@@ -87,7 +88,7 @@ static VALUE kafka_destroy()
     }
 
     rd_kafka_destroy(rk);
-    int res = rd_kafka_wait_destroyed(100);
+    res = rd_kafka_wait_destroyed(100);
     if(res) {
       error("wait_destroyed returned: %d\n", res);
     }

--- a/lib/ckafka/version.rb
+++ b/lib/ckafka/version.rb
@@ -1,3 +1,3 @@
 module Ckafka
-  VERSION = "0.2.0"
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
well that was annoying to make a PR, this is why I told you to not fork it...

I think we'll have to transfer ownership.

Anyhoo:
## wat
1. Fix logic error in init
2. do not call destroy
## why
- when I call topic_destory the kafka instance seems to never exit.  When I left it out, everything goes through super easy.  I have a feeling there was a slight change in the ordering of the delivery.
## however
- this screams like a memory leak though.  I'd prefer to not keep a list of previously used topics...
## Other things
- why isn't CI working for this branch?
- why didn't our CI catch this 

cc @DerekStride 
